### PR TITLE
Fix: add the font family icomoon on icon story

### DIFF
--- a/src/components/Icon/icon.stories.tsx
+++ b/src/components/Icon/icon.stories.tsx
@@ -3,7 +3,7 @@ import { Story } from '@ladle/react';
 import Icon from './Icon';
 
 export const iconFont: Story = () => (
-  <div>
+  <div style={{ fontFamily: 'Icomoon' }}>
     <Icon icon="at" color="active" size="large" />
   </div>
 );


### PR DESCRIPTION
Closes 
Issue-181

<details open> 
  <summary>
    <b>Bugfix</b>
  </summary>

- **Description**
The component iconfont doesn't show the icon in laddle.

- **Cause**
The laddle force the font of the base.css and doesn't allow to use the font of the component iconfont

- **Solution**
Force the icomoon font on the style in div tag
</details>

<details open> 
  <summary>
    <b>Visual evidences :framed_picture:</b>
  </summary>
![evidencia](https://github.com/hatcoders/octopost/assets/90076846/74784d49-c2a4-44f4-8f69-ebe8ccb90dc2)

</details>

<details open> 
  <summary>
    <b>Checklist</b>
  </summary>

  - [x] Issue linked
  - [x] Build working correctly
  - [ ] Tests created
</details>

<details> 
  <summary>
    <b>Additional info</b>
  </summary>
N/A
</details>
